### PR TITLE
Removing extra Finish class 

### DIFF
--- a/examples/llm_as_a_judge.py
+++ b/examples/llm_as_a_judge.py
@@ -31,13 +31,6 @@ assistant_graph = (
 )
 
 
-# Define the tool that the judge can use to indicate the response is acceptable
-class Finish(TypedDict):
-    """Tool for the judge to indicate the response is acceptable."""
-
-    finish: bool
-
-
 # Define a more detailed critique prompt with specific evaluation criteria
 critique_prompt = """You are an expert judge evaluating AI responses. Your task is to critique the AI assistant's latest response in the conversation below.
 


### PR DESCRIPTION
Openevals by default uses a bool as the tool for the judge so this class doesn't seem to be necessary. It doesn't stop the code from running but could potentially be confusing, so putting in a PR to remove it 😄 